### PR TITLE
Fix Node.js version requirement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ A powerful online JSON editor with dual-panel layout, multiple views, and AI-pow
 ## Getting Started
 
 ### Prerequisites
-- Node.js 18+
+- Node.js 20.9.0+
 
 ### Installation
 


### PR DESCRIPTION
## Summary
- README의 Node.js 최소 버전을 `18+`에서 `20.9.0+`로 수정
- Next.js 16.1.6이 실제로 요구하는 Node.js 버전(`>=20.9.0`)과 일치시킴

## Test plan
- [x] README.md의 Prerequisites 섹션에서 Node.js 버전이 `20.9.0+`로 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)