### PR TITLE
Move AI button to prominent position, remove Table view

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,7 +5,6 @@ import styles from "./page.module.css";
 import Header from "@/components/Header";
 import TextEditor from "@/components/TextEditor";
 import TreeView from "@/components/TreeView";
-import TableView from "@/components/TableView";
 import PanelHeader from "@/components/PanelHeader";
 import QueryBar from "@/components/QueryBar";
 import AdBanner from "@/components/AdBanner";
@@ -14,7 +13,7 @@ import UrlLoader from "@/components/UrlLoader";
 import ExplainPanel from "@/components/ExplainPanel";
 import FeedbackWidget from "@/components/FeedbackWidget";
 
-type ViewMode = "text" | "tree" | "table";
+type ViewMode = "text" | "tree";
 
 const DEFAULT_JSON = `{
   "region": "Asia-Pacific",
@@ -121,8 +120,6 @@ export default function Home() {
         return <TextEditor value={text} onChange={setText} />;
       case "tree":
         return <TreeView json={text} onUpdate={setText} />;
-      case "table":
-        return <TableView json={text} />;
     }
   };
 

--- a/src/components/PanelHeader.module.css
+++ b/src/components/PanelHeader.module.css
@@ -40,6 +40,31 @@
   font-weight: 600;
 }
 
+/* AI pill button */
+.aiBtn {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 12px;
+  font-size: 11px;
+  font-weight: 600;
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  border-radius: 999px;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: opacity 0.15s ease;
+}
+
+.aiBtn:hover {
+  opacity: 0.85;
+}
+
+.aiBtn:active {
+  opacity: 0.7;
+}
+
 /* Editable document name */
 .docName {
   font-size: 12px;

--- a/src/components/PanelHeader.tsx
+++ b/src/components/PanelHeader.tsx
@@ -3,7 +3,7 @@
 import { useRef, useState, useEffect } from "react";
 import styles from "./PanelHeader.module.css";
 
-type ViewMode = "text" | "tree" | "table";
+type ViewMode = "text" | "tree";
 
 interface PanelHeaderProps {
   name: string;
@@ -84,9 +84,9 @@ export default function PanelHeader({
 
   return (
     <div className={styles.panelHeader}>
-      {/* View mode pill tabs */}
+      {/* View mode pill tabs + AI button */}
       <div className={styles.viewModes}>
-        {(["text", "tree", "table"] as ViewMode[]).map((m) => (
+        {(["text", "tree"] as ViewMode[]).map((m) => (
           <button
             key={m}
             className={`${styles.viewBtn} ${view === m ? styles.viewBtnActive : ""}`}
@@ -96,6 +96,12 @@ export default function PanelHeader({
           </button>
         ))}
       </div>
+      <button className={styles.aiBtn} onClick={onExplain} title="AI Explain this JSON">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M12 2l2.4 7.2L22 12l-7.6 2.8L12 22l-2.4-7.2L2 12l7.6-2.8z"/>
+        </svg>
+        <span>AI</span>
+      </button>
 
       {/* Inline-editable document name */}
       {editingName ? (
@@ -161,14 +167,6 @@ export default function PanelHeader({
         <button className={styles.actionBtn} onClick={onSort} title="Sort keys">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
             <path d="M3 6h7M3 12h5M3 18h3M16 4l4 4-4 4M20 8H10" />
-          </svg>
-        </button>
-
-        <div className={styles.separator} />
-
-        <button className={styles.actionBtn} onClick={onExplain} title="AI Explain this JSON">
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-            <path d="M12 2l2.4 7.2L22 12l-7.6 2.8L12 22l-2.4-7.2L2 12l7.6-2.8z"/>
           </svg>
         </button>
 


### PR DESCRIPTION
## Summary
- AI Explain 버튼을 액션 아이콘 맨 끝에서 **뷰 모드 탭 옆 accent pill 버튼**으로 승격
- Table 뷰 모드 제거 (Text, Tree만 유지)
- 모바일에서 AI 기능 접근성 대폭 향상

## Before → After
- Before: `[Text] [Tree] [Table] ... [작은 아이콘들] ... [AI 아이콘]`
- After: `[Text] [Tree] [AI ✦] ... [아이콘들]`

## Test plan
- [ ] PanelHeader에 Text, Tree 탭 + AI pill 버튼 표시 확인
- [ ] Table 탭이 없는지 확인
- [ ] AI 버튼 클릭 시 ExplainPanel 모달 열림 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)